### PR TITLE
Missing slash in service url

### DIFF
--- a/src/Blockchain.php
+++ b/src/Blockchain.php
@@ -82,6 +82,9 @@ class Blockchain {
     }
 
     public function setServiceUrl($service_url) {
+        if (substr($service_url, -1, 1) != '/'){
+            $service_url = $service_url . '/';
+        }
         $this->service_url = $service_url;
     }
 


### PR DESCRIPTION
Fix for getting a "not found" error when using the library. The cause is a missing slash in the called url after the port.