### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $Blockchain->setServiceUrl('http://localhost:3000');
 
 All functionality is provided through the `Blockchain` object. 
 
-###Call Limits
+### Call Limits
 
 The [official documentation](https://blockchain.info/api) lists API call limits, which may be bypassed with an API code. If you use a code, enter it when you create the `Blockchain` object:
 
@@ -42,7 +42,7 @@ $Blockchain = new \Blockchain\Blockchain('http://localhost:3000', $my_api_code);
 
 If you need an API code, you may request one [here](https://blockchain.info/api/api_create_code).
 
-###Network Timeouts
+### Network Timeouts
 
 Set the `cURL` timeout, in seconds, with the `setTimeout` member function:
 
@@ -58,25 +58,25 @@ A Note about Bitcoin Values
 
 All Bitcoin values returned by the API are in string float format, in order to preserve full value precision. It is recommended that all arithmetic operations performed on Bitcoin values within PHP utilize the `bcmath` functions as follows:
 
-#####`bcadd` Add Two Numbers
+##### `bcadd` Add Two Numbers
 
  ```php
  $result = bcadd("101.234115", "34.92834753", 8); // "136.16246253"
  ```
 
-#####`bcsub` Subtract Two Numbers
+##### `bcsub` Subtract Two Numbers
 
 ```php
 $result = bcsub("101.234115", "34.92834753", 8); // "66.30576747"
 ```
 
-#####`bcmul` Multiply Two Numbers
+##### `bcmul` Multiply Two Numbers
 
 ```php
 $result = bcmul("101.234115", "34.92834753", 8); // "3535.940350613"
 ```
 
-#####`bcdiv` Divide Two Numbers
+##### `bcdiv` Divide Two Numbers
 
 ```php
 $result = bcdiv("101.234115", "34.92834753", 8); // "2.89833679"

--- a/docs/blockexplorer.md
+++ b/docs/blockexplorer.md
@@ -9,7 +9,7 @@ $val = $Blockchain->Explorer->someFunc($param);
 ```
 
 
-###Blocks
+### Blocks
 
 Blocks may be queried in multiple ways: by the block hash, by the height in the blockchain, or by the block's index. Calls return `Block` objects. `getBlocksAtHeight` returns an array of `Block` objects.
 
@@ -20,7 +20,7 @@ $block = $Blockchain->Explorer->getBlockByIndex($index_int);
 ```
 
 
-###Transactions
+### Transactions
 Get a single transaction based on hash or index. Returns a `Transaction` object.
 
 ```php
@@ -29,7 +29,7 @@ $tx = $Blockchain->Explorer->getTransactionByIndex($index);
 ```
 
 
-###Addresses
+### Addresses
 Get the details of an address, including a paged list of transactions. Returns an `Address` object.
 
 ```php
@@ -39,7 +39,7 @@ $address = $Blockchain->Explorer->getAddress($address, $limit, $offset);
 ```
 
 
-###Unspent Outputs
+### Unspent Outputs
 Get an array of `UnspentOutput` objects for a given address.
 
 ```php
@@ -47,7 +47,7 @@ $unspent = $Blockchain->Explorer->getUnspentOutputs($address);
 ```
 
 
-###Latest Block
+### Latest Block
 Get the latest block on the main chain. Returns a simpler `LatestBlock` object;
 
 ```php
@@ -55,7 +55,7 @@ $latest = $Blockchain->Explorer->getLatestBlock();
 ```
 
 
-###Unconfirmed Transactions
+### Unconfirmed Transactions
 Get a list of unconfirmed transactions. Returns an array of `Transaction` objects.
 
 ```php
@@ -63,7 +63,7 @@ $unconfirmed = $Blockchain->Explorer->getUnconfirmedTransactions();
 ```
 
 
-###Simple Blocks
+### Simple Blocks
 Get blocks from a particular day or from a given mining pool. Return arrays of `SimpleBlock` objects.
 
 ```php
@@ -73,7 +73,7 @@ $simple_blocks = $Blockchain->Explorer->getBlocksByPool($pool_name);
 For a list of mining pool names, visit [this page](https://blockchain.info/pools).
 
 
-###Inventory Data
+### Inventory Data
 Gets data for recent blockchain entities, up to one hour old. Returns an `InventoryData` object.
 
 ```php
@@ -86,7 +86,7 @@ Return Objects
 
 Calls to the API return first-class objects.
 
-###Block
+### Block
 
 ```php
 class Block {
@@ -109,7 +109,7 @@ class Block {
 }
 ```
 
-###Transaction
+### Transaction
 ```php
 class Transaction {
     public $double_spend = false;       // bool

--- a/docs/create.md
+++ b/docs/create.md
@@ -19,21 +19,21 @@ There are two ways to create wallets: provide an existing private key or let Blo
 
 Please read the [offical documentation](https://blockchain.info/api/create_wallet) for important details.
 
-###Create with Key
+### Create with Key
 Create a new wallet with a known private key. Returns a `WalletResponse` object.
 
 ```php
 $wallet = $Blockchain->Create->createWithKey($password, $privKey, $email=null, $label=null);
 ```
 
-###Create without Key
+### Create without Key
 Create a new wallet, letting Blockchain generate a new private key. Returns a `WalletResponse` object.
 
 ```php
 $wallet = $Blockchain->Create->create($password, $email=null, $label=null);
 ```
 
-###WalletResponse
+### WalletResponse
 The `WalletResponse` object contains fields for the wallet identifier (`guid`), the `address` for receiving Bitcoin, and a `label` for the first account of the wallet.
 
 ```php

--- a/docs/rates.md
+++ b/docs/rates.md
@@ -29,7 +29,7 @@ $rates = $Blockchain->Rates->get();
 foreach($rates as $cur=>$ticker) { ... }
 ```
 
-###Ticker
+### Ticker
 
 ```php
 class Ticker {

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -13,7 +13,7 @@ $Blockchain = new \Blockchain\Blockchain($api_code);
 $stats = $Blockchain->Stats->get();
 ```
 
-###StatsReponse
+### StatsReponse
 
 ```php
 class StatsResponse {

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -23,7 +23,7 @@ $Blockchain->Wallet->credentials('wallet-id-2', 'password-2', 'optional 2nd pass
 // ...
 ```
 
-###A Note About Bitcoin Values
+### A Note About Bitcoin Values
 
 Values returned by this API are `string` representations of the floating point Bitcoin value, with 8 decimal places of precision, like this: `"105.62774000"`.
 
@@ -32,7 +32,7 @@ Functions that send Bitcoin accept `float` and `string` Bitcoin amounts, NOT Sat
 Read more about string values on the [main documentation](../README.md).
 
 
-###Get Current Identifier
+### Get Current Identifier
 Use the `getIdentifier` function to check which wallet is active, without having to enter additional credentials. Returns a string.
 
 ```php
@@ -45,7 +45,7 @@ Balances
 Functions for fetching the balance of a whole wallet or of a particular address.
 
 
-###Wallet Balance
+### Wallet Balance
 Get the balance of the whole wallet. Returns a `string` representing the floating point balance, e.g. `"12.64952835"`.
 
 ```php
@@ -53,7 +53,7 @@ $balance = $Blockchain->Wallet->getBalance();
 ```
 
 
-###Address Balance
+### Address Balance
 Get the balance of a single wallet address. Returns a `WalletAddress` object.
 
 ```php
@@ -65,7 +65,7 @@ Transactions
 ------------
 Functions for making outgoing Bitcoin transactions from the wallet.
 
-###Send
+### Send
 Send Bitcoin to a single recipient address. The `$amount` field is either a `float` or `string` representation of the floating point value. See above note on Bitcoin values.
 
 The optional `$from_address` field specifies which wallet address from which to send the funds. An optional `$fee` amount (`float`) may be specified but must be more than the default fee listed on the [official documentation](https://blockchain.info/api/blockchain_wallet_api).
@@ -81,7 +81,7 @@ $response = $Blockchain->Wallet->send($to_address, $amount, $from_address=null, 
 $response = $Blockchain->Wallet->send("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", "0.005", null, "0.0001", "Here you go, Satoshi!");
 ```
 
-###SendMany
+### SendMany
 Send a multi-recipient transaction to many addresses at once. The `$recipients` parameter is an associative array with `address` keys and `amount` values (see example). Optional parameters are the same as with the `send` call. Returns `PaymentResponse` object and throws a `Blockchain_ApiError` exception for insufficient funds, etc.
 ```php
 $response = $Blockchain->Wallet->sendMany($recipients, $from_address=null, $fee=null, $public_note=null);
@@ -99,7 +99,7 @@ Address Management
 A wallet may contain many addresses, not all of which must be active at all times. Active addresses are monitored for activity, while archived addresses are not. It is recommended that addresses be archived when it is reasonable to assume that there will not be further activity to that address. For instance, after an invoice is filled, the payment address may be archived once the received coins are moved.
 
 
-###List Active Addresses
+### List Active Addresses
 Call `getAddresses` to return a list of the active addresses within the wallet. Returns an array of `WalletAddress` objects.
 
 ```php
@@ -107,7 +107,7 @@ $addresses = $Blockchain->Wallet->getAddresses();
 ```
 
 
-###Get New Address
+### Get New Address
 Generate a new Bitcoin address, with an optional label, less than 255 characters in length. Returns a `WalletAddress` object.
 
 ```php
@@ -115,7 +115,7 @@ $address = $Blockchain->Wallet->getNewAddress($label=null);
 ```
 
 
-###Archive Address
+### Archive Address
 Move an address to the archive. Returns `true` on success and `false` on failure.
 
 ```php
@@ -123,7 +123,7 @@ $result = $Blockchain->Wallet->archiveAddress($address);
 ```
 
 
-###Unrchive Address
+### Unrchive Address
 Move an address from the archive to the active address list. Returns `true` on success and `false` on failure.
 
 ```php
@@ -136,7 +136,7 @@ Return Objects
 
 Calls to the API usually return first-class objects.
 
-###PaymentResponse
+### PaymentResponse
 
 ```php
 class PaymentResponse {
@@ -146,7 +146,7 @@ class PaymentResponse {
 }
 ```
 
-###WalletAddress
+### WalletAddress
 
 ```php
 class WalletAddress {


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
